### PR TITLE
Corrected Character set of .toc for German translation

### DIFF
--- a/SmartBuff/SmartBuff.toc
+++ b/SmartBuff/SmartBuff.toc
@@ -3,7 +3,7 @@
 ## Version: 9.0.2.7
 ## Author: |cff20d2ffAeldra|r (EU-Proudmoore) [Unofficial fixes by Daeymien]
 ## Notes: Cast the most important buffs on you or party/raid members/pets. Use  /sbm  for options menu.
-## Notes-deDE: Castet die wichtigsten Buffs auf dich selbst, Gruppe/Raid Mitglieder/Pets. Benutze  /sbm  um das Menü zu öffnen
+## Notes-deDE: Castet die wichtigsten Buffs auf dich selbst, Gruppe/Raid Mitglieder/Pets. Benutze  /sbm  um das MenÃ¼ zu Ã¶ffnen
 ## Notes-frFR: Cast the most important buffs on you or party/raid members/pets. Use  /sbm  for options menu.
 ## eMail: aeldra@sonnenkinder.org
 ## DefaultState: Enabled


### PR DESCRIPTION
World of Warcraft needs a utf-8 encoded .toc to correctly show a umlaut.